### PR TITLE
Dijkstra agora em função da distância

### DIFF
--- a/src/graph/graph.rkt
+++ b/src/graph/graph.rkt
@@ -11,7 +11,7 @@
          "../data-structures.rkt")
 
 (provide
- dijkstra
+ Dijkstra
  to-graph
  get-distance-article-answer
  node
@@ -19,41 +19,35 @@
  node-neineighbors)
 
 ;; retorna o dijkstra a partir de qualquer distancia
-(define (dij-from dist)
-  (define (Dijkstra graph source)
-    (define (operator-less a b)
-      (< (cdr a) (cdr b)))
-    (define node-queue (make-heap operator-less))
-    (heap-add! node-queue (cons source 0))
+(define (Dijkstra graph source dist)
+  (define (operator-less a b)
+    (< (cdr a) (cdr b)))
+  (define node-queue (make-heap operator-less))
+  (heap-add! node-queue (cons source 0))
 
-    (define distances-from-source (make-hash))
-    (for ([node graph])
-      (dict-set! distances-from-source node +inf.f))
+  (define distances-from-source (make-hash))
+  (for ([node graph])
+    (dict-set! distances-from-source node +inf.f))
 
-    (dict-set! distances-from-source source 0)
-    (define previous (make-hash))
+  (dict-set! distances-from-source source 0)
+  (define previous (make-hash))
 
-    (while (not (zero? (heap-count node-queue)))
-           (match-define (cons u u-dist) (heap-min node-queue))
-           (define u-vector (node-vector u))
-           (define u-neigs (node-neineighbors u))
-           (heap-remove-min! node-queue)
-           (for ([v u-neigs])
-             (define v-vector (node-vector v))
-             (define alt (+ u-dist (dist u-vector v-vector)))
-             (if (< alt (dict-ref distances-from-source v))
-                 (block
-                  (dict-set! distances-from-source v alt)
-                  (dict-set! previous v u)
-                  (heap-add! node-queue (cons v alt)))
-                 void)))
+  (while (not (zero? (heap-count node-queue)))
+          (match-define (cons u u-dist) (heap-min node-queue))
+          (define u-vector (node-vector u))
+          (define u-neigs (node-neineighbors u))
+          (heap-remove-min! node-queue)
+          (for ([v u-neigs])
+            (define v-vector (node-vector v))
+            (define alt (+ u-dist (dist u-vector v-vector)))
+            (if (< alt (dict-ref distances-from-source v))
+                (block
+                (dict-set! distances-from-source v alt)
+                (dict-set! previous v u)
+                (heap-add! node-queue (cons v alt)))
+                void)))
 
-    (values distances-from-source previous))
-
-  Dijkstra)
-
-;; dijkstra a partir da distancia euclidiana
-(define dijkstra (dij-from dist))
+  (values distances-from-source previous))
 
 ;; Transforma em grafo, dado a primeira questão, camadas intermediarias de artigos e as respostas
 (define (to-graph question answers . list-articles)
@@ -74,7 +68,7 @@
 ;; uma camada intermediaria de artigos e uma camada final de respostas
 (define (get-distance-article-answer question articles answers [dist dist])
     (define graph (to-graph question answers articles))
-    (define-values (distances previous) ((dij-from dist) graph question))
+    (define-values (distances previous) (Dijkstra graph question dist))
     (define min-distance
         (for/fold ([dist +inf.f])
             ([answer answers])


### PR DESCRIPTION
Ao invés de uma função que retorna função, Dijkstra recebe como parâmetro a função distância.
Conforme indicação do @arademaker 